### PR TITLE
use relative include instead of Pkg.dir

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Base.Test
 const tol=1e-2;
 const integrationConfigs=[:lgrExplicit,:trapezoidal,:bkwEuler]
 
-include(Pkg.dir("NLOptControl/test/ocp.jl"))
+include("ocp.jl")
 
 
 #using NBInclude


### PR DESCRIPTION
Pkg.dir is incorrect if the package is installed and loaded from elsewhere