### PR TITLE
Fixed incorrect asserition

### DIFF
--- a/src/diffeq.jl
+++ b/src/diffeq.jl
@@ -99,7 +99,7 @@ Author: Huckleberry Febbo, Graduate Student, University of Michigan
 Date Create: 7/04/2017, Last Modified: 12/06/2019 \n
 -------------------------------------------------------------------------------------\n
 """
-function NLCon(n::NLOpt,expr::Expr,args...)::Vector{JuMP.NonlinearConstraint}
+function NLCon(n::NLOpt,expr::Expr,args...)
   if length(args) == 3
     xxx = args[1]
     uuu = args[2]


### PR DESCRIPTION
This assertion breaks some examples we are running in a lab. See code example below.
https://gist.github.com/mfalt/8f8b9143d555c987618a70a1b44cc1c3

It would be great if we could pull this, and once we are sure that the rest of the things in this package works properly, also tag a version that is 1.5 compatible.