### PR TITLE
Saving unscaled variables

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -179,7 +179,8 @@ Date Create: 1/14/2017, Last Modified: 12/06/2019 \n
 function OCPdef!(n::NLOpt{T}) where { T <: Number }
 
     # State variables
-    @variable(n.ocp.mdl, x[1:n.ocp.state.pts, 1:n.ocp.state.num])
+    varx = @variable(n.ocp.mdl, x[1:n.ocp.state.pts, 1:n.ocp.state.num])
+    n.r.ocp.xUnscaled = varx
     #n.r.ocp.x = [ @NLexpression(n.ocp.mdl, [j=1:n.ocp.state.pts], n.ocp.XS[st] * x[j,st] ) for st in 1:n.ocp.state.num ]
     n.r.ocp.x = Matrix{Any}(undef, n.ocp.state.pts,n.ocp.state.num)
     for st in 1:n.ocp.state.num
@@ -216,7 +217,8 @@ function OCPdef!(n::NLOpt{T}) where { T <: Number }
     end
 
     # control variables
-    @variable(n.ocp.mdl,u[1:n.ocp.control.pts,1:n.ocp.control.num])
+    varu = @variable(n.ocp.mdl,u[1:n.ocp.control.pts,1:n.ocp.control.num])
+    n.r.ocp.uUnscaled = varu
     #n.r.ocp.u = [ @NLexpression(n.ocp.mdl, [j=1:n.ocp.control.pts], n.ocp.CS[ctr]*u[j,ctr]) for ctr in 1:n.ocp.control.num ]
     n.r.ocp.u = Matrix{Any}(undef,n.ocp.control.pts,n.ocp.control.num)
     for ctr in 1:n.ocp.control.num

--- a/src/types.jl
+++ b/src/types.jl
@@ -100,8 +100,10 @@ end
 @with_kw mutable struct OCPResults{ T <: Number }
     tctr::Vector{Any}                           = Vector{T}()                           # Time vector for control
     tst::Vector{Any}                            = Vector{T}()                           # Time vector for state
-    x           = Matrix{Any}[]      # JuMP states
-    u           = Matrix{Any}[]      # JuMP controls
+    x           = Matrix{Any}[]      # JuMP states (scaled)
+    u           = Matrix{Any}[]      # JuMP controls (scaled)
+    xUnscaled::Matrix{Variable} = Matrix{Variable}(undef,0,0) # references to actual JuMP states
+    uUnscaled::Matrix{Variable} = Matrix{Variable}(undef,0,0) # references to actual JuMP controls
     X                        = Matrix{T}[]                   # States
     U                        =  Matrix{T}[]                 # Controls
     X0                              = Vector{T}[]                           # Initial states for OCP
@@ -132,6 +134,7 @@ end
     dfs::Vector{DataFrame}                      = Vector{DataFrame}()                   # Results in DataFrame for plotting
     dfsOpt::DataFrame                           = DataFrame()                           # Optimization information in DataFrame for plotting
     dfsCon::DataFrame                           = DataFrame()                           # Constraint data
+
 end
 
 # Optimal Control Problem (OCP) Settings


### PR DESCRIPTION
Since the variables saved in OCPResults.x is no longer actual `JuMP.Variable`s but the scaled variables and thus `NLExpression`s, there are no longer any references left to the actual JuMP variables. This makes it really hard to set the initial guess of the solution. This PR adds back these references. This makes it possible to set the initial guess, for example using the following code (at least for some model types):
```julia

function set_guess!(n, t, states, controls, tf)
    x = n.r.ocp.xUnscaled
    u = n.r.ocp.uUnscaled
    N = size(x,1)           # Number of time steps in optimization problem
    nx = size(states,2)     # Number of states
    nu = size(controls,2)   # Number of controls
    @assert nx == size(x,2) # Guess and problem have same number of states
    @assert nu == size(u,2) # Guess and problem have same number of inputs
    @assert size(states,1) == size(states,1) == length(t) # Guess has right lengths
    # Set finial time guess
    setvalue(n.ocp.tf, tf)
    for i = 1:nx # For each state
        # Interpolate guess based on time t
        xi = interpolate((t,), states[:,i], Gridded(Linear()))
        for j = 1:N                     # For each time point
            tj = tf/(N-1)*(j-1)             # Time of gridpoint j
            setvalue(x[j,i], xi(tj))    # Set guess
        end
    end
    # Set control guess
    for i = 1:nu
        ui = interpolate((t,), controls[:,i], Gridded(Linear()))
        for j = 1:N
            tj = tf/(N-1)*(j-1)
            setvalue(u[j,i], ui(tj))
        end
    end
    return
end
```